### PR TITLE
Add label and and URL for airgap support

### DIFF
--- a/helm-repositories/kaptain/kaptain-repo.yaml
+++ b/helm-repositories/kaptain/kaptain-repo.yaml
@@ -4,7 +4,10 @@ kind: HelmRepository
 metadata:
   name: kaptain-helm-repo
   namespace: kommander-flux
+  labels:
+    kommander.d2iq.io/dkp-airgapped: supported
 spec:
-  url: "http://kaptain-helm-mirror.kommander.svc"
+  url: "${helmMirrorURL:=http://kaptain-helm-mirror.kommander.svc}"
   interval: 10m
   timeout: 1m
+  


### PR DESCRIPTION
## Changes: 

- Needed label for air gap support - adds certificate for Kommander chart museum repository
- Changed URL for air-gapped substitution of helm repo