### PR TITLE
Switch to the next dev version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,61 @@
+SHELL := /bin/bash -euo pipefail
+
+REPO_ROOT := $(CURDIR)
+
+GOARCH ?= $(shell go env GOARCH)
+GOOS ?= $(shell go env GOOS)
+
+YQ_VERSION = v4.24.5
+YQ_BIN = bin/$(GOOS)/$(GOARCH)/yq
+
+SOURCE_VERSION ?=
+TARGET_VERSION ?=
+
+DEV_HELM_REPO_URL := http://kaptain-helm-mirror.kommander.svc
+RELEASE_HELM_REPO_URL := https://mesosphere.github.io/kaptain-charts
+
+HELM_REPO_URL := '${helmMirrorURL:=https://mesosphere.github.io/kaptain-charts}'
+
+.PHONY: yq
+yq: $(YQ_BIN)
+	$(call print-target)
+
+$(YQ_BIN):
+	$(call print-target)
+	mkdir -p bin/$(GOOS)/$(GOARCH)
+	curl -fsSL https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(GOOS)_$(GOARCH) -o $(YQ_BIN)
+	chmod +x $(YQ_BIN)
+
+.PHONY: validate
+validate:
+	$(call print-target)
+	@test $${SOURCE_VERSION? Please set environment variable SOURCE_VERSION}
+	@test $${TARGET_VERSION? Please set environment variable TARGET_VERSION}
+
+
+.PHONY: prepare-dev
+prepare-dev: validate
+prepare-dev: yq
+prepare-dev:
+	$(call print-target)
+	$(call create_new_version,$(SOURCE_VERSION),$(TARGET_VERSION),$(DEV_HELM_REPO_URL))
+
+.PHONY: prepare-release
+prepare-release: validate
+prepare-release: yq
+prepare-release:
+	$(call print-target)
+	$(call create_new_version,$(TARGET_VERSION_DEV),$(TARGET_VERSION),$(RELEASE_HELM_REPO_URL))
+
+define print-target
+    @printf "Executing target: \033[36m$@\033[0m\n"
+endef
+
+define create_new_version
+	cp -r $(REPO_ROOT)/services/kaptain/$(1)/ $(REPO_ROOT)/services/kaptain/$(2)/
+	$(YQ_BIN) -i '.spec.chart.spec.version = "$(2)"' $(REPO_ROOT)/services/kaptain/$(2)/kaptain.yaml
+	$(YQ_BIN) -i '.spec.valuesFrom[0].name = "kaptain-$(2)-defaults"' $(REPO_ROOT)/services/kaptain/$(2)/kaptain.yaml
+	$(YQ_BIN) -i '.metadata.name = "kaptain-$(2)-defaults"' $(REPO_ROOT)/services/kaptain/$(2)/defaults/cm.yaml
+	$(YQ_BIN) -i '.spec.url = "$${helmMirrorURL:=$(3)}"' $(REPO_ROOT)/helm-repositories/kaptain//kaptain-repo.yaml
+	git add $(REPO_ROOT)/services/kaptain/$(2)/
+endef

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# kaptain-catalog-applications
+# Kaptain Catalog Application
+
+Manifests for integration Kaptain into DKP catalog.
+
+## Development workflow
+
+To switch to the next development version:
+```sh
+make prepare-dev SOURCE_VERSION=2.0.0 TARGET_VERSION=2.1.0-dev
+```
+
+`SOURCE_VERSION` will be used as a base, `TARGET_VERSION` should match Kaptain chart version.
+
+To switch to the release version of the manifests:
+
+```sh
+make prepare-release SOURCE_VERSION=2.1.0-dev TARGET_VERSION=2.1.0
+```

--- a/helm-repositories/kaptain/kaptain-repo.yaml
+++ b/helm-repositories/kaptain/kaptain-repo.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     kommander.d2iq.io/dkp-airgapped: supported
 spec:
-  url: "${helmMirrorURL:=https://mesosphere.github.io/kaptain-charts}"
+  url: "${helmMirrorURL:=http://kaptain-helm-mirror.kommander.svc}"
   interval: 10m
   timeout: 1m
-  

--- a/services/kaptain/2.1.0-dev/defaults/cm.yaml
+++ b/services/kaptain/2.1.0-dev/defaults/cm.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kaptain-2.1.0-dev-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: ""

--- a/services/kaptain/2.1.0-dev/defaults/kustomization.yaml
+++ b/services/kaptain/2.1.0-dev/defaults/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml

--- a/services/kaptain/2.1.0-dev/kaptain.yaml
+++ b/services/kaptain/2.1.0-dev/kaptain.yaml
@@ -1,0 +1,26 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: kaptain
+  namespace: ${releaseNamespace}
+spec:
+  chart:
+    spec:
+      chart: kaptain
+      sourceRef:
+        kind: HelmRepository
+        name: kaptain-helm-repo
+        namespace: kommander-flux
+      version: 2.1.0-dev
+  interval: 15s
+  timeout: 20m
+  install:
+    remediation:
+      retries: 30
+  upgrade:
+    remediation:
+      retries: 30
+  releaseName: kaptain
+  valuesFrom:
+    - kind: ConfigMap
+      name: kaptain-2.1.0-dev-defaults

--- a/services/kaptain/2.1.0-dev/kustomization.yaml
+++ b/services/kaptain/2.1.0-dev/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kaptain.yaml
+  - ../../../helm-repositories/kaptain


### PR DESCRIPTION
This PR adds a new service version for the next Kaptain release iteration. 
The service is created by provided tooling.

There is also another PR in the https://github.com/mesosphere/kaptain/pull/722