### PR TITLE
Revert "Set CRDs to CreateReplace on upgrade"

### DIFF
--- a/helm-repositories/kaptain/kaptain-repo.yaml
+++ b/helm-repositories/kaptain/kaptain-repo.yaml
@@ -10,5 +10,3 @@ spec:
   url: "${helmMirrorURL:=http://kaptain-helm-mirror.kommander.svc}"
   interval: 10m
   timeout: 1m
-  upgrade:
-    crds: CreateReplace


### PR DESCRIPTION
Reverts PR mesosphere/kaptain-catalog-applications#8 - This was the wrong flux chart. The one we need is created by Kommander automatically...