### PR TITLE
Set the workspace namespace when installing in attached cluster

### DIFF
--- a/helm-repositories/kaptain/kaptain-repo.yaml
+++ b/helm-repositories/kaptain/kaptain-repo.yaml
@@ -7,6 +7,6 @@ metadata:
   labels:
     kommander.d2iq.io/dkp-airgapped: supported
 spec:
-  url: "${helmMirrorURL:=http://kaptain-helm-mirror.kaptain-attached-n5swr-vx27g.svc}"
+  url: "${helmMirrorURL:=http://kaptain-helm-mirror.kommander.svc}"
   interval: 10m
   timeout: 1m

--- a/helm-repositories/kaptain/kaptain-repo.yaml
+++ b/helm-repositories/kaptain/kaptain-repo.yaml
@@ -7,6 +7,6 @@ metadata:
   labels:
     kommander.d2iq.io/dkp-airgapped: supported
 spec:
-  url: "${helmMirrorURL:=http://kaptain-helm-mirror.kommander.svc}"
+  url: "${helmMirrorURL:=http://kaptain-helm-mirror.kaptain-attached-n5swr-vx27g.svc}"
   interval: 10m
   timeout: 1m

--- a/services/kaptain/2.1.0/defaults/cm.yaml
+++ b/services/kaptain/2.1.0/defaults/cm.yaml
@@ -5,4 +5,6 @@ metadata:
   name: kaptain-2.1.0-defaults
   namespace: ${releaseNamespace}
 data:
-  values.yaml: ""
+  values.yaml: |
+    global:
+      workspace: ${releaseNamespace}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Discovered during testing on [D2IQ-91359](https://jira.d2iq.com/browse/D2IQ-91359) 

Need to set the workspace name when installing in an attached cluster - several config maps rely on it.

### Why are the changes needed?

The workspace was not being set in the values.yaml in the config map when installing from the UI in an attached cluster.

### How were the changes tested?

Testing by pointing the gitrepo at this branch and installing kaptain in both the management and attached cluster.
