### PR TITLE
fix: Disallow multiple instances of Kaptain to be enabled on the cluster

### DIFF
--- a/services/kaptain/metadata.yaml
+++ b/services/kaptain/metadata.yaml
@@ -3,6 +3,7 @@ description: Enterprise-grade ML/AI platform built on pure upstream KubeFlow
 category:
   - aiml
 type: catalog
+allowMultipleInstances: false
 scope:
   - workspace
 overview: |-


### PR DESCRIPTION
### What changes were proposed in this pull request?
Disallow multiple Kaptain instances to be installed on a single cluster

### Why are the changes needed?
More context: https://mesosphere.slack.com/archives/G0157326RFD/p1658762010439519

### How were the changes tested?
Manually
