### PR TITLE
update helmMirrorURL and HR version so that we can work with v2.1.0-dev

### DIFF
--- a/helm-repositories/kaptain/kaptain-repo.yaml
+++ b/helm-repositories/kaptain/kaptain-repo.yaml
@@ -7,6 +7,6 @@ metadata:
   labels:
     kommander.d2iq.io/dkp-airgapped: supported
 spec:
-  url: "${helmMirrorURL:=https://mesosphere.github.io/kaptain-charts}"
+  url: "${helmMirrorURL:=http://kaptain-helm-mirror.kommander.svc}"
   interval: 10m
   timeout: 1m

--- a/services/kaptain/2.1.0/kaptain.yaml
+++ b/services/kaptain/2.1.0/kaptain.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: kaptain-helm-repo
         namespace: kommander-flux
-      version: 2.1.0-rc.0
+      version: 2.1.0-dev
   interval: 15s
   timeout: 20m
   install:


### PR DESCRIPTION
### Why are the changes needed?
To get kaptain versions 2.1.0-dev to be deployable again

### How were the changes tested?
Kaptain on [this PR](https://github.com/mesosphere/kaptain/pull/820) can be deployed ok
